### PR TITLE
libnone: debug/unwind friendliness, remove locals so we don't try to use them

### DIFF
--- a/libs/none/CMakeLists.txt
+++ b/libs/none/CMakeLists.txt
@@ -71,7 +71,7 @@ configure_file(merge.ar.in merge.ar)
 add_custom_command(TARGET none POST_BUILD
   COMMAND ${CMAKE_AR} -M <merge.ar
   COMMAND mv libnone.a.merged ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
-  COMMAND ${CMAKE_STRIP} --strip-debug ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
+  COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
   DEPENDS merge.ar
 )
 

--- a/libs/none/CMakeLists.txt
+++ b/libs/none/CMakeLists.txt
@@ -37,7 +37,7 @@ add_custom_command(OUTPUT ${MUSL}/config.mak
   COMMAND rm -rf "${MUSL}"
   COMMAND tar xf "${CMAKE_CURRENT_SOURCE_DIR}/musl/${MUSL}.tar.gz"
   COMMAND for PATCH in ${MUSL_PATCHES} \; do patch -p1 -d "${MUSL}" -i "${CMAKE_CURRENT_SOURCE_DIR}/$$PATCH" \; done
-  COMMAND cd ${MUSL} && CC=${CMAKE_C_COMPILER} ./configure --disable-shared CFLAGS=${MUSL_CFLAGS}
+  COMMAND cd ${MUSL} && CC=${CMAKE_C_COMPILER} ./configure --disable-shared CFLAGS=${MUSL_CFLAGS} --enable-debug
   MAIN_DEPENDENCY musl/${MUSL}.tar.gz
   DEPENDS ${MUSL_PATCHES}
   COMMENT "Configuring ${MUSL}"
@@ -69,6 +69,7 @@ configure_file(merge.ar.in merge.ar)
 add_custom_command(TARGET none POST_BUILD
   COMMAND ${CMAKE_AR} -M <merge.ar
   COMMAND mv libnone.a.merged ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
+  COMMAND ${CMAKE_STRIP} --strip-debug ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
   DEPENDS merge.ar
 )
 

--- a/libs/none/CMakeLists.txt
+++ b/libs/none/CMakeLists.txt
@@ -10,6 +10,8 @@ set(MUSL_PATCHES
   ## musl/patches/0006-configure-improve-tryflag-to-reject-ignored-opt-argu.patch
   ## musl/patches/0007-Partially-revert-remove-potentially-PIC-incompatible.patch
   ## musl/patches/0008-kludge-around-_DYNAMIC-and-our-bad-weak-symbol-handl.patch
+  musl/patches/0009-configure-don-t-force-disable-unwind-tables-let-TC-d.patch
+  musl/patches/0010-configure-don-t-add-fomit-frame-pointer.patch
 )
 
 set(MUSL_CFLAGS_EXTRA "")

--- a/libs/none/musl/patches/0009-configure-don-t-force-disable-unwind-tables-let-TC-d.patch
+++ b/libs/none/musl/patches/0009-configure-don-t-force-disable-unwind-tables-let-TC-d.patch
@@ -1,0 +1,28 @@
+From ad662224672d31d3ca9b18587e5f60d7bacea6c8 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 22 May 2018 09:18:43 -0500
+Subject: [PATCH 1/2] configure: don't force-disable unwind tables, let TC do
+ default
+
+---
+ configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 09a0c436..868d7efc 100755
+--- a/configure
++++ b/configure
+@@ -468,8 +468,8 @@ fi
+ # unstrippable. These options force them back to debug sections (and
+ # cause them not to get generated at all if debugging is off).
+ #
+-tryflag CFLAGS_AUTO -fno-unwind-tables
+-tryflag CFLAGS_AUTO -fno-asynchronous-unwind-tables
++#tryflag CFLAGS_AUTO -fno-unwind-tables
++#tryflag CFLAGS_AUTO -fno-asynchronous-unwind-tables
+ 
+ #
+ # Attempt to put each function and each data object in its own
+-- 
+2.17.0
+

--- a/libs/none/musl/patches/0010-configure-don-t-add-fomit-frame-pointer.patch
+++ b/libs/none/musl/patches/0010-configure-don-t-add-fomit-frame-pointer.patch
@@ -1,0 +1,31 @@
+From 71f07c3b9aa92c8b59b1e47a6a9a3231b6e5e584 Mon Sep 17 00:00:00 2001
+From: Will Dietz <w@wdtz.org>
+Date: Tue, 22 May 2018 09:19:49 -0500
+Subject: [PATCH 2/2] configure: don't add -fomit-frame-pointer
+
+---
+ configure | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/configure b/configure
+index 868d7efc..b1c87881 100755
+--- a/configure
++++ b/configure
+@@ -457,10 +457,10 @@ tryflag CFLAGS_AUTO -pipe
+ # anyway on most archs even when debugging is enabled since the frame
+ # pointer is no longer needed for debugging.
+ #
+-if fnmatch '-g*|*\ -g*' "$CFLAGS_AUTO $CFLAGS" ; then :
+-else 
+-tryflag CFLAGS_AUTO -fomit-frame-pointer
+-fi
++#if fnmatch '-g*|*\ -g*' "$CFLAGS_AUTO $CFLAGS" ; then :
++#else
++#tryflag CFLAGS_AUTO -fomit-frame-pointer
++#fi
+ 
+ #
+ # Modern GCC wants to put DWARF tables (used for debugging and
+-- 
+2.17.0
+

--- a/libs/none/musl/patches/README
+++ b/libs/none/musl/patches/README
@@ -1,0 +1,3 @@
+* Not all of these are used
+* Some are applied based on compiler used
+* Despite naming these are not an actual patch series


### PR DESCRIPTION
The "index" example was triggered by screen[1], FWIW.

[1] `/nix/store/kfgkvm561xicv95ry3y9y8i23dcp2pvx-screen-4.6.2-wllvm-allexe` (avail on ALLVM cache)