### PR TITLE
install-cachix.sh: use latest via 'install' api

### DIFF
--- a/.travis/install-cachix.sh
+++ b/.travis/install-cachix.sh
@@ -2,5 +2,5 @@
 
 set -eu
 
-# 0.1.2
-nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/889c72032f8595fcd7542c6032c208f6b8033db6
+# Install latest
+nix-env -iA cachix -f https://cachix.org/api/v1/install


### PR DESCRIPTION
Latest version takes advantage of improvements and fixes; so far AFAIK older versions still work but makes sense to use latest version (since cachix service itself is latest :)).

Other minor bits:
* New URL is nicer :)
* Like changing version Nix itself, upgrading Cachix is orthogonal to reproducibility (same hashes).