### PR TITLE
test: disable progress bar, looks strange in nix log

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ set(ALLVM_TEST_PARAMS
   allvm_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
 )
 set(LIT_REPORT ${CMAKE_CURRENT_BINARY_DIR}/report.xml)
-set(ALLVM_TEST_EXTRA_ARGS -sv --xunit-xml-output=${LIT_REPORT})
+set(ALLVM_TEST_EXTRA_ARGS --no-progress-bar -v --xunit-xml-output=${LIT_REPORT})
 
 # try to find 'lit'
 find_program(LIT_COMMAND llvm-lit)


### PR DESCRIPTION
Most builds are via nix these days anyway, so do easy thing and disable.