### PR TITLE
libnone: include builtins from compiler-rt

### DIFF
--- a/libs/none/CMakeLists.txt
+++ b/libs/none/CMakeLists.txt
@@ -71,18 +71,39 @@ add_custom_command(OUTPUT ${MUSL}/lib/libc.a
 add_custom_target(musl DEPENDS ${MUSL}/lib/libc.a)
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${MUSL}")
 
-# Compile our little assembly bits into a library, then merge in musl's libc.a.
+# Find the compiler-rt builtins library.
+find_library(COMPILER_RT_BUILTINS
+  NAMES libclang_rt.builtins-x86_64.a
+  PATH_SUFFIXES linux clang/${LLVM_PACKAGE_VERSION}/lib/linux
+)
+if(NOT COMPILER_RT_BUILTINS)
+  message(WARNING "compiler-rt library not found; certain allexes may fail to link")
+endif()
+
+# Compile our little assembly bits into a library, then merge in musl's libc.a
+# and compiler-rt's builtins.
+
 add_library(none STATIC unwind/UnwindRegistersRestore.S unwind/UnwindRegistersSave.S dso_handle.S dynamic.S)
 install(TARGETS none DESTINATION lib)
 set_output_directory(none BINARY_DIR ${LLVM_RUNTIME_OUTPUT_INTDIR} LIBRARY_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR})
 add_dependencies(none musl)
+
 # http://stackoverflow.com/questions/3821916/how-to-merge-two-ar-static-libraries-into-one
-configure_file(merge.ar.in merge.ar)
+set(merge_ar_path ${CMAKE_CURRENT_BINARY_DIR}/merge.ar)
+file(WRITE ${merge_ar_path}
+  "create libnone.a.merged\n"
+  "addlib ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a\n"
+  "addlib ${MUSL}/lib/libc.a\n"
+)
+if(COMPILER_RT_BUILTINS)
+  file(APPEND ${merge_ar_path} "addlib ${COMPILER_RT_BUILTINS}\n")
+endif()
+file(APPEND ${merge_ar_path} "save\nend\n")
+
 add_custom_command(TARGET none POST_BUILD
   COMMAND ${CMAKE_AR} -M <merge.ar
   COMMAND mv libnone.a.merged ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
   COMMAND ${CMAKE_STRIP} --strip-debug --strip-unneeded ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
-  DEPENDS merge.ar
 )
 
 # Install crt bits from musl, since they are useful for static linking.

--- a/libs/none/merge.ar.in
+++ b/libs/none/merge.ar.in
@@ -1,5 +1,0 @@
-create libnone.a.merged
-addlib ${LLVM_LIBRARY_OUTPUT_INTDIR}/libnone.a
-addlib ${MUSL}/lib/libc.a
-save
-end

--- a/test/lit/libcall.ll
+++ b/test/lit/libcall.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: bc2allvm %t.bc -o %t
+; RUN: ALLVM_CACHE_DIR=%t-cache allready %t
+; RUN: ALLVM_CACHE_DIR=%t-jit alley %t 0000000000000000
+; RUN: ALLVM_CACHE_DIR=%t-static alley -force-static %t 0000000000000000
+
+; Calculates a 128-bit modulo, which on x86-64 becomes a call to the function
+; __umodti3() in compiler-rt.
+
+define i32 @main(i32, i8**) {
+  %3 = getelementptr i8*, i8** %1, i64 1
+  %4 = load i8*, i8** %3
+  %5 = bitcast i8* %4 to i128*
+  %6 = load i128, i128* %5
+  %7 = urem i128 %6, 3
+  %8 = trunc i128 %7 to i32
+  ret i32 %8
+}


### PR DESCRIPTION
These include libcall functions like `__umodti3()`. LLVM's backends may generate calls to these functions even when they weren't used by the original bitcode. If we can't find compiler-rt, we print a warning and leave it out.

I ran into this problem with some functions from `cairo/src/cairo-wideint.c`. The functions appear to be dead, which explains why cairo has been working fine in ALLVM.