### PR TITLE
2020 updates: nixpkgs bump, re-enable docs, bump copyright

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -4,7 +4,7 @@ ALLVM Release License
 University of Illinois/NCSA
 Open Source License
 
-Copyright (c) 2016-2019 University of Illinois at Urbana-Champaign.
+Copyright (c) 2016-2020 University of Illinois at Urbana-Champaign.
 All rights reserved.
 
 Developed by:

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -5,9 +5,7 @@
 # Only try to build docs on x86/x86_64,
 # to avoid haskell dependency elsewhere
 # Not only is it rather heavy but not always supported
-#, buildDocs ? stdenv.hostPlatform.isx86 && !stdenv.hostPlatform.isMusl
-# XXX: restore once texlive 2019 mirror is up again
-, buildDocs ? false
+, buildDocs ? stdenv.hostPlatform.isx86 && !stdenv.hostPlatform.isMusl
 # Whoops, our tests attempt to execute x86_64 allexe's,
 # which of course doesn't work on other platforms.
 # Only run tests on x86 (and non-cross, handled by default automagic)

--- a/nix/nixpkgs-src.nix
+++ b/nix/nixpkgs-src.nix
@@ -1,6 +1,6 @@
 {
-  owner  = "dtzWill";
+  owner  = "NixOS";
   repo = "nixpkgs";
-  rev = "nixos-dtz-2019-10-28-2";
-  sha256 = "1qgbnmx0ydjqri40x7kzr12aj9zy30bdwals1kx6mdkp7s3s8fhz";
+  rev = "3fb22f785aed5d7b6946815ef1a8f99ec300c382"; # 2020-01-01
+  sha256 = "06ibfxy98bxr1ylsz9mzk4b5kfh39cav7p2d4k3rnkhr83i2k0bk";
 }

--- a/nix/nixpkgs-src.nix
+++ b/nix/nixpkgs-src.nix
@@ -1,6 +1,6 @@
 {
   owner  = "NixOS";
   repo = "nixpkgs";
-  rev = "3fb22f785aed5d7b6946815ef1a8f99ec300c382"; # 2020-01-01
-  sha256 = "06ibfxy98bxr1ylsz9mzk4b5kfh39cav7p2d4k3rnkhr83i2k0bk";
+  rev = "f55ec6fd6952d9f6ecb1a00d9d8ffca92e523a9f"; # 2020-01-07
+  sha256 = "0mblim6qzdrsc9xkgvlwin2zb2a3wb58bj2fp0hsiyss2g5b1vpb";
 }

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -39,7 +39,10 @@ let
   # Create the stack of overlays:
   overlays = [ overlay ]
     ++ (map overlayForLLVMV [ "4" "5" "6" "7" "8" "9" ])
-    ++ (map overlayForGCCV [ /* "5" "6" */ "7" "8" "9" ])
+    # Only use gcc >= default, for ABI compat with LLVM used
+    # (llvm built w/gcc9 "may" require symbols only in libstdc++ from gcc9+)
+    # Not a problem for clang toolchains as they use libstdc++ from default gcc.
+    ++ (map overlayForGCCV [ /* "5" "6" "7" "8" */ "9" ])
     ;
 
   # Import the package set using our stack of overlays,

--- a/third_party/musl/tools/add-cfi.i386.awk
+++ b/third_party/musl/tools/add-cfi.i386.awk
@@ -81,7 +81,7 @@ function adjust_sp_offset(delta) {
     in_function = 0
   }
 }
-/^\.type [a-zA-Z0-9_]+,\@function/ {
+/^\.type [a-zA-Z0-9_]+,@function/ {
   functions[substr($2, 1, length($2)-10)] = 1
 }
 # not interested in assembler directives beyond this, just pass them through

--- a/third_party/musl/tools/add-cfi.x86_64.awk
+++ b/third_party/musl/tools/add-cfi.x86_64.awk
@@ -76,7 +76,7 @@ function adjust_sp_offset(delta) {
     in_function = 0
   }
 }
-/^\.type [a-zA-Z0-9_]+,\@function/ {
+/^\.type [a-zA-Z0-9_]+,@function/ {
   functions[substr($2, 1, length($2)-10)] = 1
 }
 # not interested in assembler directives beyond this, just pass them through


### PR DESCRIPTION
Also:

* accomodate new default gcc (disable earlier versions for ABI issues)
* minor musl fix to squelch warning w/gawk5