### PR TITLE
CI: update actions, minor cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,9 @@ jobs:
   default:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: cachix/install-nix-action@v11
       with:
         skip_adding_nixpkgs_channel: true
@@ -23,7 +25,9 @@ jobs:
        variant: [default, musl]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: cachix/install-nix-action@v11
       with:
         skip_adding_nixpkgs_channel: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,11 @@ jobs:
         skip_adding_nixpkgs_channel: true
     - name: Print nix config
       run: nix show-config
-    - uses: cachix/cachix-action@v5
+    - uses: cachix/cachix-action@v6
       with:
         name: allvm
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: nix-build
   compiler-tests:
     needs: default
     strategy:
@@ -26,9 +27,8 @@ jobs:
     - uses: cachix/install-nix-action@v11
       with:
         skip_adding_nixpkgs_channel: true
-    - uses: cachix/cachix-action@v5
+    - uses: cachix/cachix-action@v6
       with:
         name: allvm
-        file: nix/release.nix 
-        attributes: '${{ matrix.variant }}'
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: nix-build nix/release.nix -A '${{ matrix.variant }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v11
-    - name: Print nix config
-      run: nix show-config
     - uses: cachix/cachix-action@v6
       with:
         name: allvm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: cachix/install-nix-action@v8
+    - uses: cachix/install-nix-action@v11
+      with:
+        skip_adding_nixpkgs_channel: true
     - name: Print nix config
       run: nix show-config
     - uses: cachix/cachix-action@v5
@@ -21,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: cachix/install-nix-action@v8
+    - uses: cachix/install-nix-action@v11
+      with:
+        skip_adding_nixpkgs_channel: true
     - uses: cachix/cachix-action@v5
       with:
         name: allvm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     needs: default
     strategy:
       matrix:
-       variant: [default, musl]
+       variant: [default, musl.allvm-tools, musl.allvm-tools-gcc9]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v11
-      with:
-        skip_adding_nixpkgs_channel: true
     - name: Print nix config
       run: nix show-config
     - uses: cachix/cachix-action@v6
@@ -29,8 +27,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: cachix/install-nix-action@v11
-      with:
-        skip_adding_nixpkgs_channel: true
     - uses: cachix/cachix-action@v6
       with:
         name: allvm


### PR DESCRIPTION
* install-nix-action v8 -> v11
* cachix-action v5 -> v6
* checkout v1 -> v2

Also:

* drop step dumping nix config
* limit build matrix by only building two musl configurations, as they're not always available in public caches.