### PR TITLE
shell.nix: fix 'nix-shell' to only pass default.nix recognized args

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
 { ... } @ args:
+let nargs = if (args?nixpkgs) then { nixpkgs = args.nixpkgs; } else {}; in
 # Pick single attr, but disable Werror flags since they
 # are likely annoying during development.
-(import ./default.nix args).allvm-tools.override { useClangWerrorFlags = false; }
+(import ./default.nix nargs).allvm-tools.override { useClangWerrorFlags = false; }


### PR DESCRIPTION
Otherwise we'd try passing in new inNixShell which isn't valid/expected.

Alternatively we could modify default.nix (and nix/release.nix) to ignore
unexpected arguments but I'd rather keep that an explicit error
for anything not supported (not nixpkgs=).