### PR TITLE
nix/build.nix: smaller tex dep

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -27,7 +27,7 @@ let
   gitshort = if src.shortRev != "0000000" then src.shortRev
              else assert builtins.pathExists ../.git; builtins.substring 0 7 (lib.commitIdFromGitRepo ../.git);
 
-  tex = texlive.combined.scheme-medium;
+  tex = texlive.combined.scheme-small;
 in
 
 stdenv.mkDerivation {


### PR DESCRIPTION
Produce same PDF result (according to diffpdf),
and reduces the dep (which fetches many small files)
considerably:

  Before: 957.0M
  After:  412.1M