### PR TITLE
ci: refine activities that trigger test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: "Test"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
 
 jobs:
   default:


### PR DESCRIPTION
In particular, this fixes running twice on pull-requests (main use).
Pushing commits to the PR branch should still trigger a run.