### PR TITLE
cleanup: doc+constify Allexe class, add overviews to tools

### DIFF
--- a/include/allvm/AOTCompile.h
+++ b/include/allvm/AOTCompile.h
@@ -9,7 +9,7 @@
 
 namespace allvm {
 
-llvm::Error AOTCompileIfNeeded(StaticBinaryCache &Cache, Allexe &allexe,
+llvm::Error AOTCompileIfNeeded(StaticBinaryCache &Cache, const Allexe &allexe,
                                llvm::StringRef LibNone, llvm::StringRef CrtBits,
                                const ALLVMLinker &Linker,
                                const CompilationOptions &Options);

--- a/include/allvm/Allexe.h
+++ b/include/allvm/Allexe.h
@@ -18,36 +18,74 @@ class LLVMContext;
 
 namespace allvm {
 
+/// An ALLVM Executable
 class Allexe {
   std::unique_ptr<ZipArchive> archive;
 
   Allexe(std::unique_ptr<ZipArchive> zipArchive);
 
 public:
+  /// returns the number of modules in the allexe
   size_t getNumModules() const;
 
+  /// return a Module object corresponding to module at specified index \p idx,
+  /// optionally returning the CRC of the module in \p crc.
+  ///
+  /// Convenience wrapper for Allexe::getModuleBuffer.
+  ///
+  /// \param idx index of module, must be valid
+  /// \param c Context to read bitcode into for the Module
+  /// \param crc optional pointer to location to write CRC of file in zip
+  /// \param shouldLoadLazyMetaData (exposed from LLVM's option of same name)
   llvm::Expected<std::unique_ptr<llvm::Module>>
-  getModule(size_t i, llvm::LLVMContext &, uint32_t *crc = nullptr,
+  getModule(size_t idx, llvm::LLVMContext &c, uint32_t *crc = nullptr,
             bool shouldLoadLazyMetaData = true) const;
 
+  /// return a buffer containing the bitcode for the module at the specified
+  /// index \p idx, optionally returning the CRC of the module
+  ///
+  /// \param idx index of module, must be valid
+  /// \param crc optional pointer to location to write CRC of file in zip
   std::unique_ptr<llvm::MemoryBuffer>
   getModuleBuffer(size_t idx, uint32_t *crc = nullptr) const;
 
+  /// return the CRC for the module at index \p idx
+  ///
+  /// \param idx index of module, must be valid
   uint32_t getModuleCRC(size_t idx) const;
+
+  /// return the (uncompressed) size of the module at index \p idx
+  ///
+  /// \param idx index of module, must be valid
   uint64_t getModuleSize(size_t idx) const;
 
+  /// return the name of the module at index \p idx
+  ///
+  /// \param idx index of module, must be valid
   llvm::StringRef getModuleName(size_t idx) const;
 
   /// add a module to this allexe
-  llvm::Error addModule(std::unique_ptr<llvm::Module>,
+  ///
+  /// \param m Module to add
+  /// \param moduleName optional name in allexe, else Module's name is used
+  llvm::Error addModule(std::unique_ptr<llvm::Module> m,
                         llvm::StringRef moduleName = "");
 
   /// load a module from disk and add it to this allexe
+  ///
+  /// \param filename path of bitcode module to add
+  /// \param moduleName optionally specify name, else \p filename is used
   llvm::Error addModule(llvm::StringRef filename,
                         llvm::StringRef moduleName = "");
 
-  /// update a module, return true if succeeds
-  llvm::Error updateModule(size_t idx, std::unique_ptr<llvm::Module>);
+  /// update/replace a module, return error on failure
+  ///
+  /// \param idx index of module to update, must be valid
+  /// \param m Module to use at index \p idx
+  llvm::Error updateModule(size_t idx, std::unique_ptr<llvm::Module> m);
+
+  /// \name Open or create Allexe's, factory methods
+  /// @{
 
   /// open a allexe for reading only
   static llvm::Expected<std::unique_ptr<const Allexe>>
@@ -56,6 +94,7 @@ public:
   /// open a allexe for reading and writing
   static llvm::Expected<std::unique_ptr<Allexe>>
   open(llvm::StringRef, const ResourcePaths &, bool overwrite = false);
+  /// @}
 };
 
 const llvm::StringRef ALLEXE_MAIN = "main.bc";

--- a/include/allvm/Allexe.h
+++ b/include/allvm/Allexe.h
@@ -26,8 +26,8 @@ class Allexe {
 public:
   size_t getNumModules() const;
 
-  std::unique_ptr<llvm::MemoryBuffer> getModuleBuffer(size_t idx,
-                                                      uint32_t *crc = nullptr) {
+  std::unique_ptr<llvm::MemoryBuffer>
+  getModuleBuffer(size_t idx, uint32_t *crc = nullptr) const {
     return archive->getEntry(idx, crc);
   }
 
@@ -52,7 +52,7 @@ public:
   llvm::Error updateModule(size_t idx, std::unique_ptr<llvm::Module>);
 
   /// open a allexe for reading only
-  static llvm::Expected<std::unique_ptr<Allexe>>
+  static llvm::Expected<std::unique_ptr<const Allexe>>
   openForReading(llvm::StringRef, const ResourcePaths &);
 
   /// open a allexe for reading and writing

--- a/include/allvm/Allexe.h
+++ b/include/allvm/Allexe.h
@@ -26,14 +26,12 @@ class Allexe {
 public:
   size_t getNumModules() const;
 
-  std::unique_ptr<llvm::MemoryBuffer>
-  getModuleBuffer(size_t idx, uint32_t *crc = nullptr) const {
-    return archive->getEntry(idx, crc);
-  }
-
   llvm::Expected<std::unique_ptr<llvm::Module>>
   getModule(size_t i, llvm::LLVMContext &, uint32_t *crc = nullptr,
             bool shouldLoadLazyMetaData = true) const;
+
+  std::unique_ptr<llvm::MemoryBuffer>
+  getModuleBuffer(size_t idx, uint32_t *crc = nullptr) const;
 
   uint32_t getModuleCRC(size_t idx) const;
   uint64_t getModuleSize(size_t idx) const;

--- a/include/allvm/ExecutionYengine.h
+++ b/include/allvm/ExecutionYengine.h
@@ -14,7 +14,7 @@ class ExecutionYengine final {
 
 public:
   struct ExecutionInfo {
-    allvm::Allexe &allexe;
+    const allvm::Allexe &allexe;
     llvm::ArrayRef<std::string> Args;
     const char **envp;
     llvm::StringRef LibNone;

--- a/include/allvm/StaticCodeGen.h
+++ b/include/allvm/StaticCodeGen.h
@@ -84,7 +84,7 @@ struct CompilationOptions {
 /// bitcode module.
 ///
 /// \returns Error::success() on success.
-llvm::Error compileAllexe(Allexe &Input, llvm::raw_pwrite_stream &OS,
+llvm::Error compileAllexe(const Allexe &Input, llvm::raw_pwrite_stream &OS,
                           const CompilationOptions &Options,
                           llvm::LLVMContext &Context);
 
@@ -95,7 +95,7 @@ llvm::Error compileAllexe(Allexe &Input, llvm::raw_pwrite_stream &OS,
 /// module.
 ///
 /// \returns Error::success() on success.
-llvm::Error compileAllexeWithLlcDefaults(Allexe &Input,
+llvm::Error compileAllexeWithLlcDefaults(const Allexe &Input,
                                          llvm::raw_pwrite_stream &OS,
                                          llvm::LLVMContext &Context);
 
@@ -106,7 +106,7 @@ llvm::Error compileAllexeWithLlcDefaults(Allexe &Input,
 ///
 /// \returns an llvm ObjectFile object on success.
 llvm::Expected<std::unique_ptr<llvm::object::ObjectFile>>
-compileAllexe(Allexe &Input, llvm::StringRef Filename,
+compileAllexe(const Allexe &Input, llvm::StringRef Filename,
               const CompilationOptions &Options, llvm::LLVMContext &Context);
 
 /// Compiles the module contained in the given allexe and writes the
@@ -117,7 +117,7 @@ compileAllexe(Allexe &Input, llvm::StringRef Filename,
 ///
 /// \returns an llvm ObjectFile object on success.
 llvm::Expected<std::unique_ptr<llvm::object::ObjectFile>>
-compileAllexeWithLlcDefaults(Allexe &Input, llvm::StringRef Filename,
+compileAllexeWithLlcDefaults(const Allexe &Input, llvm::StringRef Filename,
                              llvm::LLVMContext &Context);
 
 /// Compiles the module contained in the given allexe with the given options,
@@ -128,7 +128,7 @@ compileAllexeWithLlcDefaults(Allexe &Input, llvm::StringRef Filename,
 ///
 /// \returns an llvm Binary object on success.
 llvm::Expected<std::unique_ptr<llvm::object::Binary>> compileAndLinkAllexe(
-    Allexe &Input, llvm::StringRef LibNone, llvm::StringRef CrtBits,
+    const Allexe &Input, llvm::StringRef LibNone, llvm::StringRef CrtBits,
     const ALLVMLinker &Linker, llvm::StringRef Filename,
     const CompilationOptions &Options, llvm::LLVMContext &Context);
 
@@ -140,7 +140,8 @@ llvm::Expected<std::unique_ptr<llvm::object::Binary>> compileAndLinkAllexe(
 ///
 /// \returns an llvm Binary object on success.
 llvm::Expected<std::unique_ptr<llvm::object::Binary>>
-compileAndLinkAllexeWithLlcDefaults(Allexe &Input, llvm::StringRef LibNone,
+compileAndLinkAllexeWithLlcDefaults(const Allexe &Input,
+                                    llvm::StringRef LibNone,
                                     llvm::StringRef CrtBits,
                                     const ALLVMLinker &Linker,
                                     llvm::StringRef Filename,

--- a/include/allvm/ToolCommon.h
+++ b/include/allvm/ToolCommon.h
@@ -49,7 +49,7 @@ class ALLVMTool {
   }
 
 public:
-  ALLVMTool(llvm::StringRef _Name, llvm::StringRef _Overview = "")
+  ALLVMTool(llvm::StringRef _Name, llvm::StringRef _Overview)
       : Name(_Name), Overview(_Overview) {
     llvm::cl::SetVersionPrinter(getVersionPrinter());
   }

--- a/include/allvm/ZipArchive.h
+++ b/include/allvm/ZipArchive.h
@@ -41,14 +41,14 @@ public:
   static llvm::ErrorOr<std::unique_ptr<ZipArchive>>
   open(const llvm::Twine &Filename, bool overwrite);
 
-  std::unique_ptr<llvm::MemoryBuffer> getEntry(const llvm::Twine &Entry,
-                                               uint32_t *CrcOut = nullptr);
+  std::unique_ptr<llvm::MemoryBuffer>
+  getEntry(const llvm::Twine &Entry, uint32_t *CrcOut = nullptr) const;
 
-  std::unique_ptr<llvm::MemoryBuffer> getEntry(size_t index,
-                                               uint32_t *CrcOut = nullptr);
+  std::unique_ptr<llvm::MemoryBuffer>
+  getEntry(size_t index, uint32_t *CrcOut = nullptr) const;
 
-  uint32_t getEntryCRC(size_t index);
-  uint64_t getEntryUncompressedSize(size_t index);
+  uint32_t getEntryCRC(size_t index) const;
+  uint64_t getEntryUncompressedSize(size_t index) const;
 
   llvm::ArrayRef<std::string> listFiles() const;
 

--- a/libs/AOTCompile/AOTCompile.cpp
+++ b/libs/AOTCompile/AOTCompile.cpp
@@ -9,7 +9,7 @@
 using namespace allvm;
 using namespace llvm;
 
-Error allvm::AOTCompileIfNeeded(StaticBinaryCache &Cache, Allexe &allexe,
+Error allvm::AOTCompileIfNeeded(StaticBinaryCache &Cache, const Allexe &allexe,
                                 StringRef LibNone, StringRef CrtBits,
                                 const ALLVMLinker &Linker,
                                 const CompilationOptions &Options) {

--- a/libs/StaticCodeGen/StaticCodeGen.cpp
+++ b/libs/StaticCodeGen/StaticCodeGen.cpp
@@ -210,7 +210,7 @@ static void DiagnosticHandler(const DiagnosticInfo &DI, void *Context) {
 
 namespace allvm {
 
-Error compileAllexe(Allexe &Input, raw_pwrite_stream &OS,
+Error compileAllexe(const Allexe &Input, raw_pwrite_stream &OS,
                     const CompilationOptions &Options, LLVMContext &Context) {
   assert(Input.getNumModules() == 1 &&
          "attempted static code gen for allexe with more than one modules");
@@ -337,14 +337,14 @@ std::string CompilationOptions::serializeCompilationOptions() const {
   return buffer;
 }
 
-Error compileAllexeWithLlcDefaults(Allexe &Input, raw_pwrite_stream &OS,
+Error compileAllexeWithLlcDefaults(const Allexe &Input, raw_pwrite_stream &OS,
                                    LLVMContext &Context) {
   CompilationOptions Options;
   return compileAllexe(Input, OS, Options, Context);
 }
 
 Expected<std::unique_ptr<ObjectFile>>
-compileAllexe(Allexe &Input, StringRef Filename,
+compileAllexe(const Allexe &Input, StringRef Filename,
               const CompilationOptions &Options, LLVMContext &Context) {
 
   {
@@ -375,14 +375,14 @@ compileAllexe(Allexe &Input, StringRef Filename,
 }
 
 Expected<std::unique_ptr<ObjectFile>>
-compileAllexeWithLlcDefaults(Allexe &Input, StringRef Filename,
+compileAllexeWithLlcDefaults(const Allexe &Input, StringRef Filename,
                              LLVMContext &Context) {
   CompilationOptions Options;
   return compileAllexe(Input, Filename, Options, Context);
 }
 
 Expected<std::unique_ptr<Binary>>
-compileAndLinkAllexe(Allexe &Input, StringRef LibNone, StringRef CrtBits,
+compileAndLinkAllexe(const Allexe &Input, StringRef LibNone, StringRef CrtBits,
                      const ALLVMLinker &Linker, StringRef Filename,
                      const CompilationOptions &Options, LLVMContext &Context) {
   std::string ObjectFilename(Filename);
@@ -414,7 +414,7 @@ compileAndLinkAllexe(Allexe &Input, StringRef LibNone, StringRef CrtBits,
 }
 
 Expected<std::unique_ptr<Binary>> compileAndLinkAllexeWithLlcDefaults(
-    Allexe &Input, StringRef LibNone, StringRef CrtBits,
+    const Allexe &Input, StringRef LibNone, StringRef CrtBits,
     const ALLVMLinker &Linker, StringRef Filename, LLVMContext &Context) {
   CompilationOptions Options;
   return compileAndLinkAllexe(Input, LibNone, CrtBits, Linker, Filename,

--- a/libs/all/Allexe.cpp
+++ b/libs/all/Allexe.cpp
@@ -77,6 +77,12 @@ Allexe::getModule(size_t idx, LLVMContext &ctx, uint32_t *crc,
                                     shouldLoadLazyMetaData);
 }
 
+std::unique_ptr<llvm::MemoryBuffer>
+Allexe::getModuleBuffer(size_t idx, uint32_t *crc) const {
+  assert(idx < getNumModules() && "invalid module idx");
+  return archive->getEntry(idx, crc);
+}
+
 uint32_t Allexe::getModuleCRC(size_t idx) const {
   assert(idx < getNumModules() && "invalid module idx");
   return archive->getEntryCRC(idx);

--- a/libs/all/Allexe.cpp
+++ b/libs/all/Allexe.cpp
@@ -34,7 +34,7 @@ Allexe::Allexe(std::unique_ptr<ZipArchive> zipArchive)
 
 size_t Allexe::getNumModules() const { return archive->listFiles().size(); }
 
-Expected<std::unique_ptr<Allexe>>
+Expected<std::unique_ptr<const Allexe>>
 Allexe::openForReading(StringRef filename, const ResourcePaths &RP) {
   auto Allexe = Allexe::open(filename, RP, false);
   if (!Allexe)

--- a/libs/archive-rw/ZipArchive.cpp
+++ b/libs/archive-rw/ZipArchive.cpp
@@ -38,7 +38,7 @@ ErrorOr<std::unique_ptr<ZipArchive>> ZipArchive::open(const Twine &filename,
 }
 
 std::unique_ptr<MemoryBuffer> ZipArchive::getEntry(const Twine &entryName,
-                                                   uint32_t *crcOut) {
+                                                   uint32_t *crcOut) const {
   SmallVector<char, 256> str;
   StringRef name = entryName.toStringRef(str);
   auto entry = std::find_if(files.begin(), files.end(),
@@ -51,7 +51,7 @@ std::unique_ptr<MemoryBuffer> ZipArchive::getEntry(const Twine &entryName,
 }
 
 std::unique_ptr<MemoryBuffer> ZipArchive::getEntry(size_t index,
-                                                   uint32_t *crcOut) {
+                                                   uint32_t *crcOut) const {
   // Find the size of the file entry, and make a new MemoryBuffer of that size.
   zip_stat_t statinfo;
   zip_stat_index(archive, index, 0, &statinfo);
@@ -68,14 +68,14 @@ std::unique_ptr<MemoryBuffer> ZipArchive::getEntry(size_t index,
   return buf;
 }
 
-uint32_t ZipArchive::getEntryCRC(size_t index) {
+uint32_t ZipArchive::getEntryCRC(size_t index) const {
   zip_stat_t statinfo;
   zip_stat_index(archive, index, 0, &statinfo);
 
   return statinfo.crc;
 }
 
-uint64_t ZipArchive::getEntryUncompressedSize(size_t index) {
+uint64_t ZipArchive::getEntryUncompressedSize(size_t index) const {
   zip_stat_t statinfo;
   zip_stat_index(archive, index, 0, &statinfo);
 

--- a/tools/all-info/all-info.cpp
+++ b/tools/all-info/all-info.cpp
@@ -12,7 +12,7 @@ using namespace llvm;
 using namespace allvm;
 
 namespace {
-ALLVMTool AT("all-info");
+ALLVMTool AT("all-info", "Show information about an allexe");
 cl::opt<std::string>
     InputFilename(cl::Positional, cl::desc("<input Allexe file>"), AT.getCat());
 allvm::ExitOnError ExitOnErr;

--- a/tools/allmux/allmux.cpp
+++ b/tools/allmux/allmux.cpp
@@ -40,7 +40,9 @@ using namespace allvm;
 using namespace llvm;
 
 namespace {
-ALLVMTool AT("allmux");
+ALLVMTool AT("allmux",
+             "allvm software multiplexing tool\n\n"
+             "\tCombine multiple allexe's into a single multicall allexe\n");
 // TODO: "two-or-more"
 cl::list<std::string> InputFiles(cl::Positional, cl::OneOrMore,
                                  cl::desc("<input allexes>"), AT.getCat());

--- a/tools/allmux/allmux.cpp
+++ b/tools/allmux/allmux.cpp
@@ -55,7 +55,7 @@ cl::opt<bool> NoInternalize("no-internalize",
 allvm::ExitOnError ExitOnErr;
 
 struct Entry {
-  std::unique_ptr<Allexe> A;
+  std::unique_ptr<const Allexe> A;
   std::unique_ptr<Module> Main;
   StringRef Filename;
   StringRef Base;
@@ -64,7 +64,7 @@ struct Entry {
   std::string getDtorsName() const { return formatv("dtors_{0}", Base); }
 };
 
-std::string getModName(Allexe &A, size_t i) {
+std::string getModName(const Allexe &A, size_t i) {
   auto CRC = formatv("{0:X-}", A.getModuleCRC(i)).str();
   StringRef Name = A.getModuleName(i);
   if (sys::path::has_filename(Name))
@@ -72,10 +72,10 @@ std::string getModName(Allexe &A, size_t i) {
   return CRC;
 }
 
-std::string getLibCtorsName(Allexe &A, size_t i) {
+std::string getLibCtorsName(const Allexe &A, size_t i) {
   return formatv("ctors_{0}", getModName(A, i));
 }
-std::string getLibDtorsName(Allexe &A, size_t i) {
+std::string getLibDtorsName(const Allexe &A, size_t i) {
   return formatv("dtors_{0}", getModName(A, i));
 }
 

--- a/tools/allopt/allopt.cpp
+++ b/tools/allopt/allopt.cpp
@@ -31,7 +31,9 @@ using namespace allvm;
 using namespace llvm;
 
 namespace {
-ALLVMTool AT("allopt");
+ALLVMTool
+    AT("allopt",
+       "Invoke custom external pipeline on bitcode contents of an allexe");
 cl::opt<std::string> InputFilename("i", cl::init("-"),
                                    cl::desc("<input allexe>"), AT.getCat());
 cl::opt<std::string> OutputFilename("o", cl::init("-"),

--- a/tools/alltogether/alltogether.cpp
+++ b/tools/alltogether/alltogether.cpp
@@ -37,7 +37,8 @@ using namespace allvm;
 using namespace llvm;
 
 namespace {
-ALLVMTool AT("alltogether");
+ALLVMTool AT("alltogether",
+             "Convert allexe:{main.bc,...} -> allexe:{combined.bc}");
 cl::opt<bool> Overwrite("f", cl::desc("overwrite existing alltogether'd file"),
                         cl::init(false), AT.getCat());
 cl::opt<std::string> InputFilename(cl::Positional, cl::Required,

--- a/tools/bc2allvm/bc2allvm.cpp
+++ b/tools/bc2allvm/bc2allvm.cpp
@@ -32,7 +32,7 @@ using namespace allvm;
 using namespace llvm;
 
 namespace {
-ALLVMTool AT("bc2allvm");
+ALLVMTool AT("bc2allvm", "Create an ALLVM executable from bitcode");
 cl::opt<std::string> MainFile(cl::Positional, cl::Required,
                               cl::desc("<main LLVM bitcode file (or ll)>"),
                               AT.getCat());

--- a/tools/wllvm-dump/wllvm-dump.cpp
+++ b/tools/wllvm-dump/wllvm-dump.cpp
@@ -20,7 +20,7 @@ using namespace allvm;
 using namespace llvm;
 
 namespace {
-ALLVMTool AT("wllvm-dump");
+ALLVMTool AT("wllvm-dump", "Dump information about a file built with WLLVM");
 cl::opt<std::string> InputFilename(cl::Positional, cl::Required,
                                    cl::desc("<input file built with wllvm>"),
                                    AT.getCat());

--- a/tools/wllvm-extract/wllvm-extract.cpp
+++ b/tools/wllvm-extract/wllvm-extract.cpp
@@ -32,7 +32,8 @@ using namespace allvm;
 using namespace llvm;
 
 namespace {
-ALLVMTool AT("wllvm-extract");
+ALLVMTool AT("wllvm-extract",
+             "Extract bitcode mentioned by a file built with WLLVM");
 
 enum class OutputKind { SingleBitcode, BitcodeArchive, Allexe };
 


### PR DESCRIPTION
## Summary:

* read-only Allexe's are now `const` to encourage proper use.  Would like to rework all of that, but this is little better I think :+1: .
* tools all have "OVERVIEW: <text>" in their `-help` now
* minor re-org of methods in Allexe.h (and sink an inline method to Allexe.cpp)

See commits for more details.

## Additional Information

* `allplay` is not impacted by these changes (or continues to build/work properly anyway :))
* `updateModule` is unused (and perhaps not well tested), FWIW
* `const ZipArchive` not used but const-ify a bit anyway (`const Allexe` doesn't contain a `const ZipArchive`, for now, since via `unique_ptr<ZipArchive>`.
* "Overview" option for `ALLVMTool` is now mandatory (and has been populated where missing)
